### PR TITLE
feat: added bot option configuration and route configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,61 @@ grammy.command('start', (ctx) => ctx.reply('Welcome! Up and running.'))
 grammy.on('message', (ctx) => ctx.reply('Got another message!'))
 ```
 
+# Configuration
+
+The configuration file is located at `config/grammy.ts`. Here are the available configuration options:
+
+## Environment Variables
+
+| Variable | Type | Required | Description |
+|----------|------|----------|-------------|
+| TELEGRAM_API_TOKEN | string | Yes | Your Telegram Bot API token obtained from [@BotFather](https://t.me/BotFather) |
+| TELEGRAM_SECRET_TOKEN | string | No | Optional secret token to secure your webhook endpoint |
+
+## Configuration Options
+
+The `config/grammy.ts` file allows you to customize the following options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| apiToken | string | `process.env.TELEGRAM_API_TOKEN` | The Telegram Bot API token |
+| secretToken | string | `process.env.TELEGRAM_SECRET_TOKEN` | Optional secret token for webhook security |
+| onTimeout | 'throw' \| 'return' \| Function | 'throw' | Defines behavior when webhook request times out |
+| timeoutMilliseconds | number | 10_000 | Webhook request timeout in milliseconds |
+| botRouteName | string | apiToken | Custom route name for the webhook endpoint |
+| botConfig | object | undefined | Additional [bot configuration options](https://grammy.dev/ref/core/botconfig#botconfig) |
+
+Example configuration:
+
+```typescript
+import env from '#start/env'
+import { defineConfig } from 'adonisjs-grammy'
+
+const grammyConfig = defineConfig({
+  apiToken: env.get('TELEGRAM_API_TOKEN'),
+  secretToken: env.get('TELEGRAM_SECRET_TOKEN'),
+  
+  // Timeout handling
+  timeoutMilliseconds: 10_000, // 10 seconds
+  onTimeout: 'throw', // or 'return', or custom function
+  
+  // Custom route name (optional)
+  botRouteName: 'telegram-bot',
+  
+  // Additional bot configuration
+  botConfig: {
+    client: {
+      baseFetchConfig: {
+        compress: true,
+      },
+    },
+  },
+})
+
+export default grammyConfig
+```
+
+
 # License
 
 The MIT License (MIT). Please see [LICENSE](./LICENSE.md) file for more information.

--- a/providers/grammy_provider.ts
+++ b/providers/grammy_provider.ts
@@ -56,7 +56,7 @@ export default class GrammyProvider<C extends Context = Context> {
       this.initialized = true
     }
 
-    router.post(path ? path : apiToken, async (ctx: HttpContext) => {
+    router.post(path || apiToken, async (ctx: HttpContext) => {
       if (ctx.request.header('X-Telegram-Bot-Api-Secret-Token') !== secret) {
         return ctx.response.status(401).send('secret token is wrong')
       }

--- a/services/main.ts
+++ b/services/main.ts
@@ -8,9 +8,10 @@
  */
 
 import app from '@adonisjs/core/services/app'
-import { GrammyService } from '../src/types/main.js'
+import type { GrammyService } from '../src/types/main.js'
+import type { Context } from 'grammy'
 
-let grammy: GrammyService
+let grammy: GrammyService<Context>
 
 await app.booted(async () => {
   grammy = await app.container.make('grammy')

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -9,8 +9,9 @@
 
 import { RuntimeException } from '@poppinss/utils'
 import type { GrammyConfig } from './types/main.js'
+import type { Context } from 'grammy'
 
-export function defineConfig<T extends GrammyConfig>(config: T): T {
+export function defineConfig<C extends Context, T extends GrammyConfig<C>>(config: T): T {
   if (!config) {
     throw new RuntimeException('Invalid config file')
   }

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -11,7 +11,10 @@ import { RuntimeException } from '@poppinss/utils'
 import type { GrammyConfig } from './types/main.js'
 import type { Context } from 'grammy'
 
-export function defineConfig<C extends Context, T extends GrammyConfig<C>>(config: T): T {
+export function defineConfig<
+  C extends Context = Context,
+  T extends GrammyConfig<C> = GrammyConfig<C>,
+>(config: T): T {
   if (!config) {
     throw new RuntimeException('Invalid config file')
   }

--- a/src/grammy.ts
+++ b/src/grammy.ts
@@ -8,11 +8,12 @@
  */
 
 import { Bot } from 'grammy'
+import type { Context } from 'grammy'
 import { GrammyConfig } from './types/main.js'
 
-class Grammy extends Bot {
-  constructor(config: GrammyConfig) {
-    super(config.apiToken)
+class Grammy<C extends Context> extends Bot {
+  constructor(config: GrammyConfig<C>) {
+    super(config.apiToken, config.botConfig)
   }
 }
 

--- a/src/grammy.ts
+++ b/src/grammy.ts
@@ -11,7 +11,7 @@ import { Bot } from 'grammy'
 import type { Context } from 'grammy'
 import { GrammyConfig } from './types/main.js'
 
-class Grammy<C extends Context> extends Bot {
+class Grammy<C extends Context = Context> extends Bot {
   constructor(config: GrammyConfig<C>) {
     super(config.apiToken, config.botConfig)
   }

--- a/src/types/extended.ts
+++ b/src/types/extended.ts
@@ -1,7 +1,8 @@
-import { GrammyService } from './main.js'
+import type { GrammyService } from './main.js'
+import type { Context } from 'grammy'
 
 declare module '@adonisjs/core/types' {
   export interface ContainerBindings {
-    grammy: GrammyService
+    grammy: GrammyService<Context>
   }
 }

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -7,13 +7,16 @@
  * file that was distributed with this source code.
  */
 
+import type { BotConfig, Context } from 'grammy'
 import Grammy from '../grammy.js'
 
-export interface GrammyService extends Grammy {}
+export interface GrammyService<C extends Context = Context> extends Grammy<C> {}
 
-export interface GrammyConfig {
+export interface GrammyConfig<C extends Context = Context> {
   apiToken: string
   secretToken?: string
   onTimeout?: 'throw' | 'return' | ((...args: any[]) => unknown)
   timeoutMilliseconds?: number
+  botRouteName?: string
+  botConfig?: BotConfig<C>
 }


### PR DESCRIPTION
This Pr adds the ability to pass config options to the bot and control the route name.

Example:

```ts
import env from '#start/env'
import { defineConfig } from 'adonisjs-grammy'

const grammyConfig = defineConfig({
  apiToken: env.get('TELEGRAM_API_TOKEN'),
  secretToken: env.get('TELEGRAM_SECRET_TOKEN'),
  
  // Timeout handling
  timeoutMilliseconds: 10_000, // 10 seconds
  onTimeout: 'throw', // or 'return', or custom function
  
  // Custom route name (optional)
  botRouteName: 'telegram-bot',
  
  // Additional bot configuration
  botConfig: {
    client: {
      baseFetchConfig: {
        compress: true,
      },
    },
  },
})

export default grammyConfig
```

Closes https://github.com/sooluh/adonisjs-grammy/issues/3 and https://github.com/sooluh/adonisjs-grammy/issues/4